### PR TITLE
Indicator bug fix

### DIFF
--- a/bevel/linear_ordinal_regression.py
+++ b/bevel/linear_ordinal_regression.py
@@ -205,10 +205,12 @@ class LinearOrdinalRegression():
         y_range = np.arange(1, self.n_classes + 1)
         self._y_dict = dict(zip(y_range, y_values))
 
+        y_data = np.vectorize(dict(zip(y_values, y_range)).get)(y_data)
+
         self._indicator_plus = np.array([y_data == i + 1 for i in range(self.n_classes - 1)]) * 1.0
         self._indicator_minus = np.array([y_data - 1 == i + 1 for i in range(self.n_classes - 1)]) * 1.0
 
-        return np.vectorize(dict(zip(y_values, y_range)).get)(y_data)
+        return y_data
 
     def _get_column_names(self, X):
         if isinstance(X, DataFrame):


### PR DESCRIPTION
This is a quick fix to a bug that was causing errors with y values that were not adjacent (e.g. it was failing against ordered data of the form [0, 1, 2, 3, 5, 14])

No test yet but #11.